### PR TITLE
chore: update renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,5 +14,19 @@
   "minimumReleaseAge": "3 days",
   "rollbackPrs": true,
   "automergeStrategy": "squash",
-  "reviewers": ["@lapotor", "@whyauthentic"]
+  "reviewers": ["@lapotor", "@whyauthentic"],
+  "packageRules": [
+    {
+      "description": "Require approval for TypeScript Minor Updates",
+      "matchPackageNames": "typescript",
+      "matchUpdateTypes": "minor",
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Require approval for zone.js Minor Updates",
+      "matchPackageNames": "zone.js",
+      "matchUpdateTypes": "minor",
+      "dependencyDashboardApproval": true
+    }
+  ]
 }


### PR DESCRIPTION
Update Renovate configuration to enforce manual approval for minor updates to `typescript` and `zone.js` packages. This ensures better control over updates, emphasizing explicit approval for potential breaking changes and aligning with our versioning strategy.