### PR TITLE
chore: add PR blocking for titles when not ready

### DIFF
--- a/.github/workflows/work-in-progress.yml
+++ b/.github/workflows/work-in-progress.yml
@@ -1,0 +1,13 @@
+name: WIP
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  wip:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wip/action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Introduce action to block PRs containing a `WIP` (Work In Progress) notice in their titles. This enhancement ensures that only completed and ready-to-merge pull requests are considered, contributing to a more effective code review process.